### PR TITLE
Bugfix. Lexer Token cannot be used as array

### DIFF
--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -468,7 +468,7 @@ class Parser
         $this->lexer->moveNext();
 
         // Return the token value
-        return $this->lexer->token['value'];
+        return $this->lexer->token->value;
     }
 
     /**


### PR DESCRIPTION
Since Lexer now uses tokens as objects, they cannot be used as an array. Check \Doctrine\Common\Lexer\AbstractLexer::263